### PR TITLE
feat: #3-#4 - download data from data.calgary.ca

### DIFF
--- a/Bikeability/data_apis/connectors.py
+++ b/Bikeability/data_apis/connectors.py
@@ -1,0 +1,22 @@
+import pandas
+from sodapy import Socrata
+import os.path
+
+source_hostname="data.calgary.ca"
+pathways_endpoint = "6eun-p5zf"
+file_name = "pathways.pkl"
+
+if __name__=='__main__':
+    if not os.path.exists(file_name):
+        print(f'{file_name} does not exist. Downloading new data...')
+        client = Socrata('data.calgary.ca', None)
+        results = client.get(pathways_endpoint)
+        dataframe = pandas.DataFrame.from_records(results)
+        print(f'Data downloaded. Saving to {file_name}...')
+        dataframe.to_pickle(file_name)
+    else:
+        print(f'{file_name} exists. Loading data from disk...')
+        dataframe = pandas.read_pickle(file_name)
+
+    print(dataframe)
+


### PR DESCRIPTION
This code utilizes a Socrata client from sodapy

The pandas DataFrame will be persisted on first run,
and then loaded from the local file `pathways.pkl` if it exists.
This is to ensure we don't hit the data.calgary.ca
throttle limit on free accounts.

This DataFrame is not in the same form as those produced
by esri2gpd. It may require transformation to get at the
appropriate coordinates.